### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": "false"
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/packages.props
+++ b/packages.props
@@ -1,34 +1,34 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-	  <_ComponentHost>3.2.1</_ComponentHost>
-	  <_AutoFixture>4.11.0</_AutoFixture>
-	  <_CluedIn>4.6.0</_CluedIn>
+	  <_ComponentHost>4.0.1</_ComponentHost>
+	  <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+	  <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--
         Specified versions for dependencies in test projects
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
     <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
     <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
     <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
-    <PackageReference Update="CluedIn.Testing.Base" Version="4.0.0-*" />
+    <PackageReference Update="CluedIn.Testing.Base" Version="5.0.0-*" />
   </ItemGroup>
   <ItemGroup>
     <!--
         Specified versions for dependencies across the solution
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="$(_ComponentHost)" />
+    <PackageReference Update="ComponentHost" Version="4.0.1" />
     <PackageReference Update="CluedIn.Crawling" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.CrawlerIntegrationTesting" Version="4.0.0-*" />
+    <PackageReference Update="CluedIn.CrawlerIntegrationTesting" Version="5.0.0-*" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Core.Agent" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Server" Version="$(_CluedIn)" />

--- a/packages.props
+++ b/packages.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-	  <_ComponentHost>4.0.1</_ComponentHost>
 	  <_AutoFixture>5.0.0-preview0012</_AutoFixture>
 	  <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
@@ -11,14 +10,10 @@
     -->
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
     <PackageReference Update="xunit.v3" Version="3.2.2" />
     <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
-    <PackageReference Update="Shouldly" Version="3.0.2" />
     <PackageReference Update="CluedIn.Testing.Base" Version="5.0.0-*" />
   </ItemGroup>
   <ItemGroup>
@@ -26,13 +21,9 @@
         Specified versions for dependencies across the solution
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="4.0.1" />
     <PackageReference Update="CluedIn.Crawling" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.CrawlerIntegrationTesting" Version="5.0.0-*" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.Core.Agent" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.Server" Version="$(_CluedIn)" />
-    <PackageReference Update="CluedIn.Server.Common.WebApi" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />
   </ItemGroup>
 </Project>

--- a/src/ExternalSearch.Providers.GoogleImages.Provider/Provider.ExternalSearch.GoogleImages.csproj
+++ b/src/ExternalSearch.Providers.GoogleImages.Provider/Provider.ExternalSearch.GoogleImages.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="CluedIn.Core" />
-    <PackageReference Include="ComponentHost" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ExternalSearch.Providers.GoogleImages/ExternalSearch.Providers.GoogleImages.csproj
+++ b/src/ExternalSearch.Providers.GoogleImages/ExternalSearch.Providers.GoogleImages.csproj
@@ -1,12 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-        <LangVersion>latest</LangVersion>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-        <LangVersion>latest</LangVersion>
-    </PropertyGroup>
-
     <ItemGroup>
       <None Remove="Resources\google-icon-logo.svg" />
     </ItemGroup>

--- a/src/ExternalSearch.Providers.GoogleImages/GoogleImagesExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.GoogleImages/GoogleImagesExternalSearchProvider.cs
@@ -128,7 +128,7 @@ namespace CluedIn.ExternalSearch.Providers.GoogleImages
 
             if (!query.QueryParameters.TryGetValue("companyName", out var parameter)) yield break;
             var name = parameter.FirstOrDefault();
-            var request = new RestRequest($"?key={apiKey}&cx=000950167190857528722:vf0rypkbf0w&q={name}&searchType=image", Method.GET);
+            var request = new RestRequest($"?key={apiKey}&cx=000950167190857528722:vf0rypkbf0w&q={name}&searchType=image", Method.Get);
            
             var response = client.ExecuteAsync<ImageDetailsResponse>(request).Result;
                
@@ -230,7 +230,7 @@ namespace CluedIn.ExternalSearch.Providers.GoogleImages
             var apiToken = jobData.ApiToken;
             var client = new RestClient("https://www.googleapis.com/customsearch/v1");
             
-            var request = new RestRequest($"?key={apiToken}&cx=000950167190857528722:vf0rypkbf0w&q=Google&searchType=image", Method.GET);
+            var request = new RestRequest($"?key={apiToken}&cx=000950167190857528722:vf0rypkbf0w&q=Google&searchType=image", Method.Get);
 
             var response = client.ExecuteAsync<ImageDetailsResponse>(request).Result;
 
@@ -238,7 +238,7 @@ namespace CluedIn.ExternalSearch.Providers.GoogleImages
             return response.Data == null ? new ConnectionVerificationResult(true, string.Empty) : ConstructVerifyConnectionResponse(response);
         }
 
-        private static ConnectionVerificationResult ConstructVerifyConnectionResponse(IRestResponse response)
+        private static ConnectionVerificationResult ConstructVerifyConnectionResponse(RestResponse response)
         {
             var errorMessageBase = $"{Constants.ProviderName} returned \"{(int)response.StatusCode} {response.StatusDescription}\".";
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" />
+    <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="coverlet.msbuild" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Moq" />
   </ItemGroup>

--- a/test/integration/Integration.Tests/GoogleImagesTests.cs
+++ b/test/integration/Integration.Tests/GoogleImagesTests.cs
@@ -6,7 +6,6 @@ using CluedIn.ExternalSearch.Providers.GoogleImages;
 using CluedIn.Testing.Base.ExternalSearch;
 using Moq;
 using Xunit;
-using Xunit.Abstractions;
 
 //using TestContext = CluedIn.Tests.Unit.TestContext;
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`; `LangVersion` removed (defaults to C# 13)
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`